### PR TITLE
Update to Ruby 2.4.2

### DIFF
--- a/linux
+++ b/linux
@@ -61,7 +61,7 @@ if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 fi
 
-ruby_version="2.3.4"
+ruby_version="2.4.2"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"


### PR DESCRIPTION
2.3.4 won't compile under Ubuntu 17.10 and 2.4.2 is what is in a standard production Docker container