### PR TITLE
bump ruby version to 2.5.3

### DIFF
--- a/linux
+++ b/linux
@@ -62,7 +62,7 @@ if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 fi
 
-ruby_version="2.5.1"
+ruby_version="2.5.3"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"

--- a/mac
+++ b/mac
@@ -80,7 +80,7 @@ log_info "Upgrading and linking OpenSSL ..."
 log_info "Installing image libs ..."
   brew install advancecomp gifsicle jhead jpegoptim jpeg optipng pngcrush pngquant
 
-ruby_version="2.5.1"
+ruby_version="2.5.3"
 
 log_info "Installing Ruby $ruby_version ..."
   rbenv install "$ruby_version"


### PR DESCRIPTION
Discourse now requires Ruby v2.5.2+
https://github.com/discourse/discourse/commit/bdc2757d58445d5653710d4f6ec88a22b159635d