### PR TITLE
Nodejs 8.x is no longer supported

### DIFF
--- a/linux
+++ b/linux
@@ -84,7 +84,7 @@ log_info "Installing Mailcatcher ..."
   gem install mailcatcher
 
 log_info "Installing Node.js ..."
-  curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
   sudo apt-get install -y nodejs
   sudo npm install -g svgo
   sudo npm install -g yarn

--- a/linux
+++ b/linux
@@ -84,7 +84,7 @@ log_info "Installing Mailcatcher ..."
   gem install mailcatcher
 
 log_info "Installing Node.js ..."
-  curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   sudo apt-get install -y nodejs
   sudo npm install -g svgo
   sudo npm install -g yarn

--- a/linux
+++ b/linux
@@ -83,7 +83,7 @@ log_info "Installing Bundler ..."
 log_info "Installing Mailcatcher ..."
   gem install mailcatcher
 
-log_info "Installing Node.js ..."
+log_info "Installing Node.js 10 ..."
   curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
   sudo apt-get install -y nodejs
   sudo npm install -g svgo


### PR DESCRIPTION
This is a very tiny change.Node 8 is no longer supported.The best way is update it to node 10.

changes:

```shell
curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -    //old
curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -     //new
```
Note | Second commit is from nodejs 12 to nodejs 10. Because this branch is based on my nodejs 12 branch.