### PR TITLE
Install imagemagick with HEIC support

### DIFF
--- a/linux
+++ b/linux
@@ -38,7 +38,11 @@ log_info "Installing curl ..."
   sudo apt-get -y install curl
 
 log_info "Installing ImageMagick ..."
-  sudo apt-get -y install imagemagick
+  sudo apt-get install libtool
+  wget https://raw.githubusercontent.com/discourse/discourse_docker/48ea79fb1792fbc84ab10939459d5bf25bc0332c/image/base/install-imagemagick
+  chmod +x install-imagemagick
+  sudo ./install-imagemagick
+#  sudo apt-get -y install imagemagick
 
 log_info "Installing image utilities ..."
   sudo apt-get -y install advancecomp gifsicle jpegoptim libjpeg-progs optipng pngcrush pngquant

--- a/linux
+++ b/linux
@@ -39,10 +39,9 @@ log_info "Installing curl ..."
 
 log_info "Installing ImageMagick ..."
   sudo apt-get install libtool
-  wget https://raw.githubusercontent.com/discourse/discourse_docker/48ea79fb1792fbc84ab10939459d5bf25bc0332c/image/base/install-imagemagick
+  wget https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-imagemagick
   chmod +x install-imagemagick
   sudo ./install-imagemagick
-#  sudo apt-get -y install imagemagick
 
 log_info "Installing image utilities ..."
   sudo apt-get -y install advancecomp gifsicle jpegoptim libjpeg-progs optipng pngcrush pngquant

--- a/linux
+++ b/linux
@@ -38,7 +38,7 @@ log_info "Installing curl ..."
   sudo apt-get -y install curl
 
 log_info "Installing ImageMagick ..."
-  sudo apt-get install libtool
+  sudo apt-get -y install libtool
   wget https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-imagemagick
   chmod +x install-imagemagick
   sudo ./install-imagemagick
@@ -91,4 +91,3 @@ log_info "Installing Node.js 10 ..."
   sudo apt-get install -y nodejs
   sudo npm install -g svgo
   sudo npm install -g yarn
-


### PR DESCRIPTION
This will be useful in the context of https://github.com/discourse/discourse/pull/10079. 

Note also that the package manager installs ImageMagick 6, whereas our docker image uses IM 7. 