### PR TITLE
Install redis 6.2+ from official redis repo

### DIFF
--- a/linux
+++ b/linux
@@ -32,7 +32,10 @@ log_info "Installing Postgres ..."
   sudo apt-get -y install postgresql postgresql-server-dev-all postgresql-contrib libpq-dev
 
 log_info "Installing Redis ..."
-  sudo apt-get -y install redis-server
+  curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+  sudo apt-get update
+  sudo apt-get -y install redis
 
 log_info "Installing curl ..."
   sudo apt-get -y install curl


### PR DESCRIPTION
This allows to install v6.2+ required for example by Discourse